### PR TITLE
(fix) prevent element selectors of css from applying styles globally

### DIFF
--- a/src/procedures-ordered/procedure-dialogs/add-to-worklist-dialog.scss
+++ b/src/procedures-ordered/procedure-dialogs/add-to-worklist-dialog.scss
@@ -7,7 +7,7 @@
   margin: spacing.$spacing-03 0;
 }
 
-section {
+.section {
   margin: spacing.$spacing-03;
 }
 

--- a/src/procedures-ordered/procedure-instructions/instructions.scss
+++ b/src/procedures-ordered/procedure-instructions/instructions.scss
@@ -1,7 +1,7 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 
-section {
+.section {
   margin: spacing.$spacing-03;
 }
 

--- a/src/results/result-form.scss
+++ b/src/results/result-form.scss
@@ -2,7 +2,7 @@
 @use '@carbon/styles/scss/type';
 
 
-section {
+.section {
   margin: spacing.$spacing-03;
 }
 


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
Add a fix to prevent element selectors of CSS from applying styles globally. Ends up breaking the forms works.
#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
